### PR TITLE
Changed TCL_VERSION to TCL_PATCH_LEVEL

### DIFF
--- a/bind/pdflib/tcl/pdflib_tcl.c
+++ b/bind/pdflib/tcl/pdflib_tcl.c
@@ -880,7 +880,7 @@ SWIGEXPORT(int,Pdflib_Init)(Tcl_Interp *interp)
  	return TCL_ERROR;
     }
 #else
-    if (Tcl_PkgRequire(interp, "Tcl", TCL_VERSION, 1) == NULL) {
+    if (Tcl_PkgRequire(interp, "Tcl", TCL_PATCH_LEVEL, 1) == NULL) {
  	return TCL_ERROR;
     }
 #endif

--- a/bind/pdflib/tcl/pdflib_tcl.c
+++ b/bind/pdflib/tcl/pdflib_tcl.c
@@ -24,6 +24,8 @@
  * if building with older TCL Versions than 8.2 you have to undef this
  */
 #define USE_TCL_STUBS
+
+/* Tcl 8.6 Compatibility when undef USE_TCL_STUBS */
 #ifndef USE_TCL_STUBS
 #define USE_INTERP_RESULT 1
 #endif

--- a/bind/pdflib/tcl/pdflib_tcl.c
+++ b/bind/pdflib/tcl/pdflib_tcl.c
@@ -24,6 +24,9 @@
  * if building with older TCL Versions than 8.2 you have to undef this
  */
 #define USE_TCL_STUBS
+#ifndef USE_TCL_STUBS
+#define USE_INTERP_RESULT 1
+#endif
 
 #include <tcl.h>
 

--- a/bind/pdflib/tcl/readme.txt
+++ b/bind/pdflib/tcl/readme.txt
@@ -50,4 +50,6 @@ Do the following for building PDFlib with Tcl 8.0 or 8.1:
 
 - #undef USE_TCL_STUBS in pdflib_tcl.c
 
+- #define USE_INTERP_RESULT 1 in tcl_wrapped.c
+
 - Add -ltcl to the linker command, and an appropriate -L option.

--- a/bind/pdflib/tcl/tcl_wrapped.c
+++ b/bind/pdflib/tcl/tcl_wrapped.c
@@ -1,3 +1,6 @@
+/* Set this to define when not useing stubs for tcl 8.6 compatibility. */
+#undef USE_INTERP_RESULT 1
+
 #if defined(_WRAP_CODE)
 
     


### PR DESCRIPTION
When compiling with #undef USE_TCL_STUBS I got an error on 'require pdflib' that Tcl  8.6.1 needed to be exactly 8.6.  Changing TCL_VERSION to TCL_PATCH_LEVEL fixed the error.
